### PR TITLE
rename make*Guard functions to *Guard

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -10,9 +10,9 @@
 		"addUntrackedFiles": true
 	},
 	"github": {
-		"release": false,
+		"release": true,
 		"makeLatest": true,
-		"assets": ["build/*"],
+		"assets": ["dist/*"],
 		"comments": {
 			"issue": ":rocket: _This issue has been resolved in v${version}. See [${releaseName}](${releaseUrl}) for release notes._",
 			"pr": ":rocket: _This pull request is included in v${version}. See [${releaseName}](${releaseUrl}) for release notes._",

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ npm install @presidio-dev/hai-guardrails
 Here's a simple example of using the Injection Guard to protect your LLM application:
 
 ```typescript
-import { makeInjectionGuard, GuardrailsEngine } from '@presidio-dev/hai-guardrails'
+import { injectionGuard, GuardrailsEngine } from '@presidio-dev/hai-guardrails'
 
 // Create a simple injection guard with heuristic detection
-const injectionGuard = makeInjectionGuard(
+const injectionGuard = injectionGuard(
 	{ roles: ['user'] }, // Only check user messages
 	{ mode: 'heuristic', threshold: 0.5 } // Use heuristic detection with 0.5 threshold
 )
@@ -173,19 +173,16 @@ Prevents prompt injection attacks by detecting and blocking attempts to manipula
 **Example usage**:
 
 ```typescript
-import { makeInjectionGuard } from '@presidio-dev/hai-guardrails'
+import { injectionGuard } from '@presidio-dev/hai-guardrails'
 
 // Heuristic detection
-const heuristicGuard = makeInjectionGuard(
-	{ roles: ['user'] },
-	{ mode: 'heuristic', threshold: 0.5 }
-)
+const heuristicGuard = injectionGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.5 })
 
 // Pattern matching
-const patternGuard = makeInjectionGuard({ roles: ['user'] }, { mode: 'pattern', threshold: 0.5 })
+const patternGuard = injectionGuard({ roles: ['user'] }, { mode: 'pattern', threshold: 0.5 })
 
 // Language model detection (requires an LLM)
-const lmGuard = makeInjectionGuard(
+const lmGuard = injectionGuard(
 	{ roles: ['user'], llm: yourLLMProvider },
 	{ mode: 'language-model', threshold: 0.5 }
 )
@@ -232,9 +229,9 @@ Prevents information leakage by detecting and blocking attempts to extract syste
 **Example usage**:
 
 ```typescript
-import { makeLeakageGuard } from '@presidio-dev/hai-guardrails'
+import { leakageGuard } from '@presidio-dev/hai-guardrails'
 
-const leakageGuard = makeLeakageGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.5 })
+const leakageGuard = leakageGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.5 })
 ```
 
 **Example output**:
@@ -274,9 +271,9 @@ Detects and redacts personally identifiable information (PII) such as emails, ph
 **Example usage**:
 
 ```typescript
-import { makePIIGuard, SelectionType } from '@presidio-dev/hai-guardrails'
+import { piiGuard, SelectionType } from '@presidio-dev/hai-guardrails'
 
-const piiGuard = makePIIGuard({
+const piiGuard = piiGuard({
 	selection: SelectionType.All, // Check all messages
 })
 ```
@@ -316,9 +313,9 @@ Detects and redacts secrets such as API keys, access tokens, credentials, and ot
 **Example usage**:
 
 ```typescript
-import { makeSecretGuard, SelectionType } from '@presidio-dev/hai-guardrails'
+import { secretGuard, SelectionType } from '@presidio-dev/hai-guardrails'
 
-const secretGuard = makeSecretGuard({
+const secretGuard = secretGuard({
 	selection: SelectionType.All, // Check all messages
 })
 ```
@@ -356,26 +353,23 @@ The GuardrailsEngine allows you to compose multiple guards for comprehensive pro
 ```typescript
 import {
 	GuardrailsEngine,
-	makeInjectionGuard,
-	makeLeakageGuard,
-	makePIIGuard,
-	makeSecretGuard,
+	injectionGuard,
+	leakageGuard,
+	piiGuard,
+	secretGuard,
 	SelectionType,
 } from '@presidio-dev/hai-guardrails'
 
 // Create guards
-const injectionGuard = makeInjectionGuard(
-	{ roles: ['user'] },
-	{ mode: 'heuristic', threshold: 0.7 }
-)
+const injectionGuard = injectionGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.7 })
 
-const leakageGuard = makeLeakageGuard({ roles: ['user'] }, { mode: 'pattern', threshold: 0.6 })
+const leakageGuard = leakageGuard({ roles: ['user'] }, { mode: 'pattern', threshold: 0.6 })
 
-const piiGuard = makePIIGuard({
+const piiGuard = piiGuard({
 	selection: SelectionType.All,
 })
 
-const secretGuard = makeSecretGuard({
+const secretGuard = secretGuard({
 	selection: SelectionType.All,
 })
 
@@ -400,7 +394,7 @@ console.log(JSON.stringify(results, null, 2))
 You can use any LLM provider that matches the signature `(messages: LLMMessage[]) => Promise<LLMMessage[]>`:
 
 ```typescript
-import { makeInjectionGuard } from '@presidio-dev/hai-guardrails'
+import { injectionGuard } from '@presidio-dev/hai-guardrails'
 import type { LLMMessage } from '@presidio-dev/hai-guardrails/types/types'
 import OpenAI from 'openai'
 
@@ -445,7 +439,7 @@ const customLLMProvider = async (messages: LLMMessage[]): Promise<LLMMessage[]> 
 }
 
 // Use your custom provider with the language model detection tactic
-const languageModelGuard = makeInjectionGuard(
+const languageModelGuard = injectionGuard(
 	{
 		roles: ['user'],
 		llm: customLLMProvider,
@@ -544,19 +538,19 @@ type GuardOptions = {
    // guardrails.ts
    import {
    	GuardrailsEngine,
-   	makeInjectionGuard,
-   	makePIIGuard,
+   	injectionGuard,
+   	piiGuard,
    	SelectionType,
    } from '@presidio-dev/hai-guardrails'
 
    // Create a simple guardrails engine with injection and PII protection
    export function createGuardrails() {
-   	const injectionGuard = makeInjectionGuard(
+   	const injectionGuard = injectionGuard(
    		{ roles: ['user'] },
    		{ mode: 'heuristic', threshold: 0.7 }
    	)
 
-   	const piiGuard = makePIIGuard({
+   	const piiGuard = piiGuard({
    		selection: SelectionType.All,
    	})
 
@@ -604,37 +598,37 @@ For comprehensive protection, you can combine multiple guards with different con
 ```typescript
 import {
 	GuardrailsEngine,
-	makeInjectionGuard,
-	makeLeakageGuard,
-	makePIIGuard,
-	makeSecretGuard,
+	injectionGuard,
+	leakageGuard,
+	piiGuard,
+	secretGuard,
 	SelectionType,
 } from '@presidio-dev/hai-guardrails'
 
 // Create a function to set up comprehensive guardrails
 export function createComprehensiveGuardrails(llmProvider) {
 	// Injection protection with multiple tactics
-	const heuristicInjectionGuard = makeInjectionGuard(
+	const heuristicInjectionGuard = injectionGuard(
 		{ roles: ['user'] },
 		{ mode: 'heuristic', threshold: 0.7 }
 	)
 
-	const patternInjectionGuard = makeInjectionGuard(
+	const patternInjectionGuard = injectionGuard(
 		{ roles: ['user'] },
 		{ mode: 'pattern', threshold: 0.7 }
 	)
 
-	const lmInjectionGuard = makeInjectionGuard(
+	const lmInjectionGuard = injectionGuard(
 		{ roles: ['user'], llm: llmProvider },
 		{ mode: 'language-model', threshold: 0.7 }
 	)
 
 	// Leakage protection
-	const leakageGuard = makeLeakageGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.6 })
+	const leakageGuard = leakageGuard({ roles: ['user'] }, { mode: 'heuristic', threshold: 0.6 })
 
 	// PII and secret protection
-	const piiGuard = makePIIGuard({ selection: SelectionType.All })
-	const secretGuard = makeSecretGuard({ selection: SelectionType.All })
+	const piiGuard = piiGuard({ selection: SelectionType.All })
+	const secretGuard = secretGuard({ selection: SelectionType.All })
 
 	// Create engine with all guards
 	return new GuardrailsEngine({

--- a/examples/apps/langchain-chat/README.md
+++ b/examples/apps/langchain-chat/README.md
@@ -68,16 +68,16 @@ The application creates a simple chat interface in the terminal using Node.js's 
 This example demonstrates how **effortlessly** you can integrate HAI Guardrails with LangChain. With just a few lines of code, you can add robust security features to your LLM applications:
 
 ```typescript
-import { GuardrailsEngine, makePIIGuard, makeSecretGuard } from '@presidio-dev/hai-guardrails'
+import { GuardrailsEngine, piiGuard, secretGuard } from '@presidio-dev/hai-guardrails'
 import { LangChainChatGuardrails, SelectionType } from '@presidio-dev/hai-guardrails'
 
 // 1. Create a guardrails engine with your desired guards
 const guardRailsEngine = new GuardrailsEngine({
 	guards: [
-		makePIIGuard({
+		piiGuard({
 			selection: SelectionType.All,
 		}),
-		makeSecretGuard({
+		secretGuard({
 			selection: SelectionType.All,
 		}),
 	],

--- a/examples/apps/langchain-chat/index.ts
+++ b/examples/apps/langchain-chat/index.ts
@@ -3,7 +3,7 @@ import { HumanMessage, SystemMessage, BaseMessage } from '@langchain/core/messag
 import { stdin as input, stdout as output } from 'node:process'
 import * as readline from 'node:readline/promises'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
-import { GuardrailsEngine, makePIIGuard, makeSecretGuard } from '@presidio-dev/hai-guardrails'
+import { GuardrailsEngine, piiGuard, secretGuard } from '@presidio-dev/hai-guardrails'
 import { LangChainChatGuardrails, SelectionType } from '@presidio-dev/hai-guardrails'
 
 class ChatInstance {
@@ -70,10 +70,10 @@ const model = new ChatGoogleGenerativeAI({
 
 const guardRailsEngine = new GuardrailsEngine({
 	guards: [
-		makePIIGuard({
+		piiGuard({
 			selection: SelectionType.All,
 		}),
-		makeSecretGuard({
+		secretGuard({
 			selection: SelectionType.All,
 		}),
 	],

--- a/examples/byop.ts
+++ b/examples/byop.ts
@@ -1,4 +1,4 @@
-import { makeInjectionGuard } from '../src'
+import { injectionGuard } from '../src'
 import type { LLMMessage } from '../src'
 import OpenAI from 'openai'
 
@@ -69,7 +69,7 @@ const messages = [
 ]
 
 // Create a language model detection tactic
-const languageModelLeakingTactic = makeInjectionGuard(
+const languageModelLeakingTactic = injectionGuard(
 	{
 		roles: ['user'],
 		llm: customLLMProvider,

--- a/examples/injection.ts
+++ b/examples/injection.ts
@@ -1,5 +1,5 @@
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai'
-import { makeInjectionGuard } from '../src'
+import { injectionGuard } from '../src'
 
 const messages = [
 	{
@@ -12,7 +12,7 @@ const messages = [
 	},
 ]
 
-const heuristicLeakingGuard = makeInjectionGuard(
+const heuristicLeakingGuard = injectionGuard(
 	{
 		roles: ['user'],
 	},
@@ -57,7 +57,7 @@ console.log(heuristic)
 //   }
 // ]
 
-const patternLeakingTactic = makeInjectionGuard(
+const patternLeakingTactic = injectionGuard(
 	{
 		roles: ['user'],
 	},
@@ -106,7 +106,7 @@ const geminiLLM = new ChatGoogleGenerativeAI({
 	apiKey: process.env.GOOGLE_API_KEY, // Make sure to set this environment variable
 })
 
-const languageModelLeakingTactic = makeInjectionGuard(
+const languageModelLeakingTactic = injectionGuard(
 	{
 		roles: ['user'],
 		llm: geminiLLM,

--- a/examples/langchain-guardrails.ts
+++ b/examples/langchain-guardrails.ts
@@ -1,7 +1,7 @@
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai'
 import { GuardrailsEngine } from '../src'
 import { LangChainChatGuardrails } from '../src'
-import { makePIIGuard, makeSecretGuard } from '../src'
+import { piiGuard, secretGuard } from '../src'
 import { SelectionType } from '../src'
 
 async function main() {
@@ -14,10 +14,10 @@ async function main() {
 	// 2. Initialize the Guardrails engine (configure as needed)
 	const guardrailsEngine = new GuardrailsEngine({
 		guards: [
-			makePIIGuard({
+			piiGuard({
 				selection: SelectionType.All,
 			}),
-			makeSecretGuard({
+			secretGuard({
 				selection: SelectionType.All,
 			}),
 		],

--- a/examples/leakage.ts
+++ b/examples/leakage.ts
@@ -1,5 +1,5 @@
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai'
-import { makeLeakageGuard } from '../src'
+import { leakageGuard } from '../src'
 
 const messages = [
 	{
@@ -12,7 +12,7 @@ const messages = [
 	},
 ]
 
-const heuristicLeakingGuard = makeLeakageGuard(
+const heuristicLeakingGuard = leakageGuard(
 	{
 		roles: ['user'],
 	},
@@ -57,7 +57,7 @@ console.log(heuristic)
 //   }
 // ]
 
-const patternLeakingTactic = makeLeakageGuard(
+const patternLeakingTactic = leakageGuard(
 	{
 		roles: ['user'],
 	},
@@ -106,7 +106,7 @@ const geminiLLM = new ChatGoogleGenerativeAI({
 	apiKey: process.env.GOOGLE_API_KEY, // Make sure to set this environment variable
 })
 
-const languageModelLeakingTactic = makeLeakageGuard(
+const languageModelLeakingTactic = leakageGuard(
 	{
 		roles: ['user'],
 		llm: geminiLLM,

--- a/examples/pii.ts
+++ b/examples/pii.ts
@@ -1,10 +1,10 @@
-import { makePIIGuard } from '../src'
+import { piiGuard } from '../src'
 import { GuardrailsEngine } from '../src'
 import { SelectionType } from '../src'
 
 const engine = new GuardrailsEngine({
 	guards: [
-		makePIIGuard({
+		piiGuard({
 			selection: SelectionType.All,
 		}),
 	],

--- a/examples/secret.ts
+++ b/examples/secret.ts
@@ -1,9 +1,9 @@
-import { makeSecretGuard, SelectionType } from '../src'
+import { secretGuard, SelectionType } from '../src'
 import { GuardrailsEngine } from '../src'
 
 const engine = new GuardrailsEngine({
 	guards: [
-		makeSecretGuard({
+		secretGuard({
 			selection: SelectionType.All,
 		}),
 	],

--- a/src/guards/injection.guard.ts
+++ b/src/guards/injection.guard.ts
@@ -141,7 +141,7 @@ const patternInjectionTactic = new Pattern(0.5, InjectionPatterns)
 const languageModelInjectionTactic = (llm: LLM) =>
 	new LanguageModel(0.5, llm, RenderPromptForInjectionDetection)
 
-export function makeInjectionGuard(
+export function injectionGuard(
 	opts: GuardOptions = {},
 	extra: {
 		mode: 'heuristic' | 'pattern' | 'language-model'

--- a/src/guards/leakage.guard.ts
+++ b/src/guards/leakage.guard.ts
@@ -62,7 +62,7 @@ const patternLeakingTactic = new Pattern(0.5, LeakingPatterns)
 const languageModelLeakingTactic = (llm: LLM) =>
 	new LanguageModel(0.5, llm, RenderPromptForLeakingDetection)
 
-export function makeLeakageGuard(
+export function leakageGuard(
 	opts: GuardOptions = {},
 	extra: {
 		mode: 'heuristic' | 'pattern' | 'language-model'

--- a/src/guards/pii.guard.ts
+++ b/src/guards/pii.guard.ts
@@ -64,7 +64,7 @@ function redactPII(input: string): string {
 	}, input)
 }
 
-export function makePIIGuard(opts: GuardOptions = {}): Guard {
+export function piiGuard(opts: GuardOptions = {}): Guard {
 	return makeGuard({
 		...opts,
 		id: 'pii',

--- a/src/guards/secret.guard.ts
+++ b/src/guards/secret.guard.ts
@@ -298,7 +298,7 @@ function redactSecrets(
 type SecretGuardOptions = GuardOptions & {
 	patterns?: SecretPattern[]
 }
-export function makeSecretGuard(opts: SecretGuardOptions = {}): Guard {
+export function secretGuard(opts: SecretGuardOptions = {}): Guard {
 	const patterns = [...DEFAULT_SECRET_PATTERNS, ...(opts.patterns || [])]
 	return makeGuard({
 		...opts,


### PR DESCRIPTION
This commit renames the `make*Guard` functions to `*Guard` for consistency and improved readability.