### PR TITLE
Removed pino in transport which is not required since vscode runs in …

### DIFF
--- a/src/utils/logging/pino-logger.ts
+++ b/src/utils/logging/pino-logger.ts
@@ -31,18 +31,15 @@ import {
  * @property {boolean} options.singleLine - Force single-line output
  */
 const DEFAULT_TRANSPORT_OPTIONS = {
-	target: process.env.NODE_ENV === 'development' ? 'pino-pretty' : 'pino',
-	options:
-		process.env.NODE_ENV === 'development'
-			? {
-					colorize: true,
-					translateTime: 'SYS:standard',
-					ignore: 'pid,hostname',
-					levelFirst: true,
-					hideObjects: false,
-					singleLine: false,
-				}
-			: {},
+	target: 'pino-pretty',
+	options: {
+		colorize: true,
+		translateTime: 'SYS:standard',
+		ignore: 'pid,hostname',
+		levelFirst: true,
+		hideObjects: false,
+		singleLine: false,
+	},
 }
 
 /**
@@ -179,7 +176,7 @@ export class PinoLogger extends AbstractLogger {
 export const createPinoLogger = (
 	options: PinoLoggerOptions = {
 		logLevel: DEFAULT_LOG_LEVEL,
-		transport: DEFAULT_TRANSPORT_OPTIONS,
+		transport: process.env.NODE_ENV === 'development' ? DEFAULT_TRANSPORT_OPTIONS : undefined,
 	}
 ): LoggerContract => {
 	return new PinoLogger(options)


### PR DESCRIPTION
…lower vm (#53)

* chore: npm publish internally calls prepublish which lacks --production flag

* chore: removed pino in transport which is not required since vscode runs in lower vm

* chore: setting transport to undefined. even pino in transport blocks the build